### PR TITLE
migrate to new ftp server for legacy diplib (version 2 and lower)

### DIFF
--- a/sec_dum_gettingstarted.html
+++ b/sec_dum_gettingstarted.html
@@ -274,7 +274,7 @@ the figure look prettier):</p>
 <h2 id="sec_dum_gettingstarted_where_to_go">Where to go from here</h2>
 <p>If you are new to <em>MATLAB</em>, it would be a good idea to read the &ldquo;Getting
 Started with <em>MATLAB</em>&rdquo; manual. If you are new to image processing, you can
-read <a href="https://qiftp.tudelft.nl/diplib/docs/FIP2.3.pdf">&ldquo;The Fundamentals of Image Processing&rdquo;</a>.</p>
+read <a href="https://ftp.imphys.tudelft.nl/DIPimage/docs/FIP2.3.pdf">&ldquo;The Fundamentals of Image Processing&rdquo;</a>.</p>
 <p>Before you start using this toolbox, we recommend that you read
 <a href="sec_dum_dip_image.html">The <code>dip_image</code> Object</a> (at least <a href="sec_dum_dip_image.html#sec_dum_dip_image_review">Review of the differences between a <code>dip_image</code> and a <em>MATLAB</em> array</a>).
 It contains very important information on the <code>dip_image</code> object and its

--- a/sec_dum_introduction.html
+++ b/sec_dum_introduction.html
@@ -98,7 +98,7 @@ and <a href="index.html">its documentation</a>.</p>
 toolbox, not as a tutorial on image analysis. Although
 <a href="sec_dum_gettingstarted.html">Getting Started</a> shows some image analysis basics, it
 is not complete. We refer to
-<a href="https://qiftp.tudelft.nl/diplib/docs/FIP2.3.pdf">&ldquo;The Fundamentals of Image Processing&rdquo;</a>.</p>
+<a href="https://ftp.imphys.tudelft.nl/DIPimage/docs/FIP2.3.pdf">&ldquo;The Fundamentals of Image Processing&rdquo;</a>.</p>
 <h2 id="sec_dum_introduction_conventions">Documentation conventions</h2>
 <p>The following conventions are used throughout this manual:</p>
 <ul>


### PR DESCRIPTION
The server `qiftp.tudelft.nl` is replaced with `ftp.imphys.tudelft.nl`. This pull request modifies the documentation accordingly.